### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,30 +102,30 @@ Some of them are not in the list, some i'm not using anymore, but I have some kn
     <span width="75%" height="100%" vertical-align="top">
         <picture>
             <source
-                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api?username=faelmori&count_private=true&show_icons=true&theme=radical&line_height=29&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff"
+                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api?username=faelmori&count_private=true&show_icons=true&theme=radical&line_height=27&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff"
                     media="(prefers-color-scheme: radical)"
             />
             <source
-                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api?username=faelmori&count_private=true&show_icons=true&theme=radical&line_height=29&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff"
+                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api?username=faelmori&count_private=true&show_icons=true&theme=radical&line_height=27&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff"
                     media="(prefers-color-scheme: radical), (prefers-color-scheme: no-preference)"
             />
             <img
-                 src="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api?username=faelmori&count_private=true&show_icons=true&theme=radical&line_height=29&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff"
+                 src="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api?username=faelmori&count_private=true&show_icons=true&theme=radical&line_height=27&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff"
                  alt="GitHub Stats"/>
         </picture>
     </span>
     <span width="25%">
         <picture>
             <source
-                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api/top-langs?username=faelmori&hide=javascript,batchfile,tex,ejs,rich%20text%20format,less,css,roff,text,markup,scss,html&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff&langs_count=10&show_icons=true&theme=radical&layout=compact&card_width=500"
+                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api/top-langs?username=faelmori&hide=javascript,batchfile,tex,ejs,rich%20text%20format,less,css,roff,text,markup,scss,html&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff&langs_count=10&show_icons=true&theme=radical&layout=compact&card_width=440"
                     media="(prefers-color-scheme: radical)"
             />
             <source
-                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api/top-langs?username=faelmori&hide=javascript,batchfile,tex,ejs,rich%20text%20format,less,css,roff,text,markup,scss,html&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff&langs_count=10&show_icons=true&theme=radical&layout=compact&card_width=500"
+                    srcset="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api/top-langs?username=faelmori&hide=javascript,batchfile,tex,ejs,rich%20text%20format,less,css,roff,text,markup,scss,html&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff&langs_count=10&show_icons=true&theme=radical&layout=compact&card_width=440"
                     media="(prefers-color-scheme: radical), (prefers-color-scheme: no-preference)"
             />
             <img
-                 src="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api/top-langs?username=faelmori&hide=javascript,batchfile,tex,ejs,rich%20text%20format,less,css,roff,text,markup,scss,html&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff&langs_count=10&show_icons=true&theme=radical&layout=compact&card_width=500"
+                 src="https://github-readme-stats-git-main-faelmoris-projects.vercel.app/api/top-langs?username=faelmori&hide=javascript,batchfile,tex,ejs,rich%20text%20format,less,css,roff,text,markup,scss,html&bg_color=0d1117&text_color=ffffff&icon_color=ffffff&title_color=ffffff&langs_count=10&show_icons=true&theme=radical&layout=compact&card_width=440"
                  alt="GitHub Languages Stats"/>
         </picture>
     </span>


### PR DESCRIPTION
This pull request updates the `README.md` file to adjust the visual presentation of GitHub stats and language stats by modifying the `line_height` and `card_width` parameters in the embedded URLs.

Visual adjustments:

* Updated the `line_height` parameter in the GitHub stats section from `29` to `27` to refine the spacing in the stats display. (`README.md`, [README.mdL105-R128](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R128))
* Adjusted the `card_width` parameter in the language stats section from `500` to `440` to make the layout more compact. (`README.md`, [README.mdL105-R128](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R128))